### PR TITLE
Upgrade to operator-sdk v0.8.1 with operator prometheus metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docker-build docker-push docker-update create-project switch-project delete-project create-crd delete-crd create-operator delete-operator update-operator create-cr update-cr delete-cr all clean help
+.PHONY: docker-build docker-push docker-update create-project switch-project delete-project create-crd delete-crd create-operator delete-operator create-cr delete-cr all clean help
 
 .DEFAULT_GOAL := help
 
@@ -6,7 +6,7 @@ MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 THISDIR_PATH := $(patsubst %/,%,$(abspath $(dir $(MKFILE_PATH))))
 
 IMAGE ?= slopezz/ansible-hello-world-operator
-VERSION ?= v1.0.0
+VERSION ?= v1.1.0
 NAMESPACE ?= example
 
 docker-build: ## Build operator Docker image
@@ -18,7 +18,8 @@ docker-push: ## Push operator Docker image to remote registry
 docker-update: docker-build docker-push ## Build and Push operator Docker image to remote registry
 
 create-project: ## Create OCP project for the operator
-	oc new-project $(NAMESPACE)
+	oc new-project $(NAMESPACE) || true
+	oc label namespace $(NAMESPACE) monitoring=enabled || true
 	oc project $(NAMESPACE)
 
 switch-project: ## Swith to OCP project for the operator
@@ -28,38 +29,36 @@ delete-project: ## Delete OCP project for the operator
 	oc delete --force project $(NAMESPACE) || true
 
 create-crd: switch-project ## Create Operator CRD
-	oc create -f deploy/crds/crd.yaml
+	oc create -f deploy/crds/crd.yaml || true
 
 delete-crd: switch-project ## Delete Operator CRD
-	oc delete -f deploy/crds/crd.yaml
+	oc delete -f deploy/crds/crd.yaml || true
 
-create-operator: switch-project ## Create Operator objects (remember to set correct image on deploy/operator.yaml)
-	oc create -f deploy/service_account.yaml
-	oc create -f deploy/role.yaml
-	oc create -f deploy/role_binding.yaml
-	oc create -f deploy/operator.yaml
-
-update-operator: switch-project ## Update Operator main object (Deployment)
+create-operator: switch-project ## Create/Update Operator objects (remember to set correct image on deploy/operator.yaml)
+	oc apply -f deploy/service_account.yaml
+	oc apply -f deploy/role.yaml
+	oc apply -f deploy/role_binding.yaml
 	oc apply -f deploy/operator.yaml
+	oc apply -f deploy/operator-service.yaml
+	oc apply -f deploy/operator-servicemonitor.yaml
 
 delete-operator: switch-project ## Delete Operator objects
-	oc delete -f deploy/operator.yaml
-	oc delete -f deploy/role_binding.yaml
-	oc delete -f deploy/role.yaml
-	oc delete -f deploy/service_account.yaml
+	oc delete -f deploy/operator-servicemonitor.yaml || true
+	oc delete -f deploy/operator-service.yaml || true
+	oc delete -f deploy/operator.yaml || true
+	oc delete -f deploy/role_binding.yaml || true
+	oc delete -f deploy/role.yaml || true
+	oc delete -f deploy/service_account.yaml || true
 
-create-cr: switch-project ## Create specific CR
-	oc create -f deploy/crds/cr.yaml
-
-update-cr: switch-project ## Update specific CR
+create-cr: switch-project ## Create/Update specific CR
 	oc apply -f deploy/crds/cr.yaml
 
 delete-cr: switch-project ## Delete specific CR
-	oc delete -f deploy/crds/cr.yaml
+	oc delete -f deploy/crds/cr.yaml || true
 
-all: create-project create-crd create-operator create-cr ## Create all: OCP project, CRD, Operator, CR
+all: create-project create-crd create-operator create-cr ## Create all: OCP-project, CRD, Operator, CR
 
-clean: delete-cr delete-operator delete-crd delete-project ## Clean all resources: CR, Operator, CRD, OCP project
+clean: delete-cr delete-operator delete-crd delete-project ## Clean all resources: CR, Operator, CRD, OCP-project
 
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.6.0
+FROM quay.io/operator-framework/ansible-operator:v0.8.1
 
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml

--- a/deploy/crds/cr.yaml
+++ b/deploy/crds/cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: hello-world-operator.com/v1alpha1
 kind: HelloWorld
 metadata:
-  name: example-helloworld
+  name: example
 spec:
   helloWorldIsImageLatestTag: "2.0"
   helloWorldIsImageTag: "2.0"
@@ -11,4 +11,4 @@ spec:
   helloWorldDcResourcesRequestsMemory: "64Mi"
   helloWorldDcResourcesLimitsCpu: "100m"
   helloWorldDcResourcesLimitsMemory: "128Mi"
-  helloWorldRouteHosts: "hello-world-example.apps.ocp-40.net"
+  helloWorldRouteHosts: "hello-world-example.ocp-cluster.net"

--- a/deploy/operator-service.yaml
+++ b/deploy/operator-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-world-operator
+  labels:
+    name: hello-world-operator
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 8383
+    protocol: TCP
+    targetPort: 8383
+  selector:
+    name: hello-world-operator

--- a/deploy/operator-servicemonitor.yaml
+++ b/deploy/operator-servicemonitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hello-world-operator
+  labels:
+    name: hello-world-operator
+    monitoring: 'enabled'
+spec:
+  selector:
+    matchLabels:
+      name: hello-world-operator
+  endpoints:
+  - interval: 15s
+    port: metrics
+    path: /metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,7 +19,7 @@ spec:
           - /usr/local/bin/ao-logs
           - /tmp/ansible-operator/runner
           - stdout
-          image: "slopezz/ansible-hello-world-operator:v1.0.0"
+          image: "slopezz/ansible-hello-world-operator:v1.1.0"
           imagePullPolicy: "Always"
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
@@ -29,8 +29,12 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: operator
-          image: "slopezz/ansible-hello-world-operator:v1.0.0"
+          image: "slopezz/ansible-hello-world-operator:v1.1.0"
           imagePullPolicy: "Always"
+          ports:
+          - containerPort: 8383
+            name: metrics
+            protocol: TCP
           volumeMounts:
           - mountPath: /tmp/ansible-operator/runner
             name: runner

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -52,12 +52,17 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  verbs:
+  - '*'
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors
   verbs:
-  - get
-  - create
+  - '*'
 - apiGroups:
   - apps
   resourceNames:
@@ -68,13 +73,6 @@ rules:
   - update
 - apiGroups:
   - hello-world-operator.com
-  resources:
-  - '*'
-  verbs:
-  - '*'
-# Needed 3 x "*" only on OCP 3.11 (if not HTTP 403), on OCP 4.0 is not needed
-- apiGroups:
-  - '*'
   resources:
   - '*'
   verbs:

--- a/roles/hello-world/tasks/main.yml
+++ b/roles/hello-world/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Get details of deployed hello-world DeploymentConfig if exists for CR {{ meta.name }} on project {{ meta.namespace }}
   k8s_facts:
-    api_version: v1
+    api_version: apps.openshift.io/v1
     kind: DeploymentConfig
     namespace: "{{ meta.namespace }}"
     name: "{{ meta.name }}-hello-world"

--- a/roles/hello-world/templates/hello-world-deploymentconfig.yml.j2
+++ b/roles/hello-world/templates/hello-world-deploymentconfig.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   name: "{{ meta.name }}-hello-world"

--- a/roles/hello-world/templates/hello-world-imagestream.yml.j2
+++ b/roles/hello-world/templates/hello-world-imagestream.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: "{{ meta.name }}-hello-world"

--- a/roles/hello-world/templates/hello-world-route.yml.j2
+++ b/roles/hello-world/templates/hello-world-route.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: "{{ meta.name }}-hello-world"


### PR DESCRIPTION
- Upgrade operator version to operator-sdk v0.8.1
- Include new operator `Service` and `ServiceMonitor` objects because now operator `Deployment` includes built-in prometheus metrics
- Fix RBAC permissions
- Fix Openshift ApiVersion on specific Openshift objects (`DeploymentConfig`, `ImageStream`, `Route`) because although it was not needed on `v0.6.0`, now it is mandatory
- Improve README
- Improve Makefile